### PR TITLE
Add springio/antora-xref-extension

### DIFF
--- a/neuvector-playbook-local.yml
+++ b/neuvector-playbook-local.yml
@@ -23,6 +23,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: '@springio/antora-xref-extension'
 
 output:
   dir: build/site

--- a/neuvector-playbook.yml
+++ b/neuvector-playbook.yml
@@ -22,6 +22,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: '@springio/antora-xref-extension'
 
 output:
   dir: build/site

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@antora/lunr-extension": "^1.0.0-alpha.8",
+        "@springio/antora-xref-extension": "^1.0.0-alpha.4",
         "asciidoctor-kroki": "^0.18.1"
       },
       "devDependencies": {
@@ -391,6 +392,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@springio/antora-xref-extension": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@springio/antora-xref-extension/-/antora-xref-extension-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-ybIqQaNgK2pjAkOAd/A+IXK5AmxDZcKfpsp528UXIG2N3L4KFwvwljhANHktS0HHiN5QMZp0PuD0WZsClpenhQ==",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@vscode/gulp-vinyl-zip": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "devDependencies": {
-    "antora": "3.1.9",
-    "http-server": "^14.1.1",
     "@antora/cli": "3.1.7",
     "@antora/site-generator": "3.1.7",
-    "@asciidoctor/tabs": "^1.0.0-beta.6"
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "antora": "3.1.9",
+    "http-server": "^14.1.1"
   },
   "dependencies": {
-    "asciidoctor-kroki": "^0.18.1",
-    "@antora/lunr-extension": "^1.0.0-alpha.8"
+    "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@springio/antora-xref-extension": "^1.0.0-alpha.4",
+    "asciidoctor-kroki": "^0.18.1"
   }
 }


### PR DESCRIPTION
Adds the [spring-io/antora-xref-extension](https://github.com/spring-io/antora-xref-extension) extension as Antora's built-in validation doesn't support xrefs with fragments (i.e. linking to the header of another file). 

Note, CI for this PR itself runs with the extension enabled and broken links of this type are considered `ERROR` level by the extension. If there are any such broken links, CI won't pass until the links are fixed.

Depends on #19.