### PR TITLE
5.4.6 Release Note/CVE

### DIFF
--- a/docs/5.4/modules/en/nav.adoc
+++ b/docs/5.4/modules/en/nav.adoc
@@ -96,4 +96,4 @@
 ** xref:runtime_security.adoc[5.x Runtime Security]
 ** xref:notifications.adoc[5.x Notifications]
 * Security Advisories and CVEs
-** xref:Exposure-ManagerContainerLogs.adoc[Sensitive Information Exposure in NeuVector Manager Container Logs]
+** xref:cve.adoc[Security Advisories and CVEs]

--- a/docs/5.4/modules/en/pages/5x.adoc
+++ b/docs/5.4/modules/en/pages/5x.adoc
@@ -13,7 +13,7 @@ To receive email notifications of new releases, please subscribe to this SUSE ma
 
 === 5.4.6 August 2025
 
-==== New Features:
+==== New Features
 
 * *NVSHAS-6733*: Export response rules as CRD.
 * *NVSHAS-9899*: NeuVector Process Profile Alerts for Java Services contain sensitive data.
@@ -30,7 +30,7 @@ To receive email notifications of new releases, please subscribe to this SUSE ma
 * *NVSHAS-9985*:	NeuVector (Fed Master) creates a problem for all requests coming from outside.
 * *NVSHAS-9981*:	Security Event is triggered whenever a new "Process Profile Rule" is added or changed in a group.
 
-==== Security Advisories:
+==== Security Advisories
 
 * https://github.com/neuvector/neuvector/security/advisories/GHSA-8pxw-9c75-6w56[Admin account has insecure default password]
 * https://github.com/neuvector/neuvector/security/advisories/GHSA-8ff6-pc43-jwv3[Insecure password management vulnerable to rainbow attacks]
@@ -40,11 +40,11 @@ See the xref:cve.adoc[Security Advisory and CVEs] documentation for more informa
 
 === 5.4.5 July 2025
 
-==== New Features:
+==== New Features
 
 * *NVSHAS-9776*: Add etcd toleration in Helm chart.
 
-==== Bug Fixes:
+==== Bug Fixes
 
 * *NVSHAS-9507*: OCI container not getting scanned.
 * *NVSHAS-9787*: Remove unnecessary manager log.
@@ -85,7 +85,7 @@ See the xref:cve.adoc[Security Advisory and CVEs] documentation for more informa
 
 === 5.4.4 May 2025
 
-==== New Features:
+==== New Features
 
 * **NVSHAS-9915**: Show scan results from the Harbor scanner module in the NeuVector UI.
 * **NVSHAS-9904**: Expose `imagePullPolicy` to `values.yaml` for each component.
@@ -95,7 +95,7 @@ See the xref:cve.adoc[Security Advisory and CVEs] documentation for more informa
 * **NVSHAS-8160**: [Controller] Adjust some items for Security Risk Score calculation.
 * **NVSHAS-4673**: Suggestion to add message before exporting groups.
 
-==== Bug Fixes:
+==== Bug Fixes
 
 * **NVSHAS-9931**: Add a warning if there are inconsistent versions of NeuVector products in multi-cluster.
 * **NVSHAS-9925**: `/v1/scan/asset/images` API on the Registry Page fails.
@@ -114,7 +114,7 @@ See the xref:cve.adoc[Security Advisory and CVEs] documentation for more informa
 
 === 5.4.3 March 2025
 
-==== New Features:
+==== New Features
 
 * **NVSHAS-9793**: Allow Fed Global roles in LDAP/userinitcfg when deploying NeuVector through the ConfigMap and Secret.
 * **NVSHAS-9764**: [RFE] Add support for Azure for "Remote Repository Configuration".
@@ -127,7 +127,7 @@ See the xref:cve.adoc[Security Advisory and CVEs] documentation for more informa
 * **NVSHAS-7997**: Scanner connector for ghcr.io.
 * **NVSHAS-7982**: Assign WAF sensors from Federation Master.
 
-==== Bug Fixes:
+==== Bug Fixes
 
 * **NVSHAS-9849**: Enforcers not registering with controllers.
 * **NVSHAS-9847**: Wildcard filters not working for Docker registry.
@@ -154,7 +154,7 @@ See the xref:cve.adoc[Security Advisory and CVEs] documentation for more informa
 
 === 5.4.2 January 2025
 
-==== New Features:
+==== New Features
 
 * **NVSHAS-9726**: The monitor now passes proxy URL.
 * **NVSHAS-9719**: Announces the retirement of built-in certificates.
@@ -164,7 +164,7 @@ See the xref:cve.adoc[Security Advisory and CVEs] documentation for more informa
 * **NVSHAS-9590**: Ability to choose which vulnerability score for all assets.
 * **NVSHAS-7555**: Include "Auto Refresh" option under Security Events.
 
-==== Bug Fixes:
+==== Bug Fixes
 
 * **NVSHAS-9662**: Inconsistent Role/RoleBinding logic in Helm chart 2.8.2.
 * **NVSHAS-9652**: Observed difference in syslog format in splunk.
@@ -245,14 +245,14 @@ Please note the stand-alone scanner will not be affected by these changes.
 
 === 5.4.1 November 2024
 
-==== New Features:
+==== New Features
 
 * **NVSHAS-8583**: Setting granular policy modes for rule sets, separate network policy mode and profile mode at per group level.
 * **NVSHAS-9440**: Support separate network mode and Process and File mode in CRD.
 * **NVSHAS-9369**: Add debug log category via helm deployment support for controller.
 * **NVSHAS-9040**: Improve syslog message when admission control rule is denied in monitor mode.
 
-==== Bug Fixes:
+==== Bug Fixes
 
 * **NVSHAS-9416**: [Scanner] activemq-all-5.8.0.redhat-60024.jar can NOT be detected with any vul (but previous scanner build can).
 * **NVSHAS-9447**: Controller/Scanner pods crashing - "Unsupported system Exit".
@@ -320,7 +320,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 ** Cloud billing data archiving.
 ** Namespace boundary enforcement.
 
-==== New Features:
+==== New Features
 
 * **NVSHAS-9012**: Displaying Rancher SSO users on NV UI that have the same user name.
 * **NVSHAS-8939**: Provide an option on NV UI so that Rancher SSO session users can drop the current JWT token (i.e. logout).
@@ -357,7 +357,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 * **NVSHAS-7945**: Support DISA STIG benchmark for Kubernetes.
 * **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
-==== Bug Fixes:
+==== Bug Fixes
 
 * **NVSHAS-9005**: TypeError in registries: Cannot read properties of undefined (reading 'total_records').
 * **NVSHAS-9085**: Assets View PDF report shows 0% vulnerability even with present vulnerabilities.

--- a/docs/5.4/modules/en/pages/5x.adoc
+++ b/docs/5.4/modules/en/pages/5x.adoc
@@ -1,5 +1,5 @@
 = 5.x Release Notes
-:revdate: 2025-05-23
+:revdate: 2025-08-26
 :page-revdate: {revdate}
 :page-opendocs-origin: /14.releasenotes/01.5x/01.5x.md
 :page-opendocs-slug:  /releasenotes/5x
@@ -10,6 +10,31 @@
 ====
 To receive email notifications of new releases, please subscribe to this SUSE mailing list: https://lists.suse.com/mailman/listinfo/neuvector-updates
 ====
+
+=== 5.4.6 August 2025
+
+==== New Features:
+
+* *NVSHAS-6733*: Export response rules as CRD.
+* *NVSHAS-9899*: NeuVector Process Profile Alerts for Java Services contain sensitive data.
+* *NVSHAS-9990*: Adopt new hash algorithm for user passwords.
+* *NVSHAS-9968*: Support setting default admin account's default password.
+
+==== Bugs Fixed
+
+* *NVSHAS-10062*: Manager not showing ERROR when failing to create admin password during 1st login.
+* *NVSHAS-10041*: Federation operation failed "invalid data" when configuring federation through ConfigMap.
+* *NVSHAS-10018*: Neuvector is not scanning all images in GitLab Registry.
+* *NVSHAS-10017*: False Positive Security Alert related to allowed process.
+* *NVSHAS-10001*: Protect/Monitor enforcements "linger" after group deletion.
+* *NVSHAS-9985*:	NeuVector (Fed Master) creates a problem for all requests coming from outside.
+* *NVSHAS-9981*:	Security Event is triggered whenever a new "Process Profile Rule" is added or changed in a group.
+
+==== Security Advisories:
+
+* https://github.com/neuvector/neuvector/security/advisories/GHSA-8pxw-9c75-6w56[Admin account has insecure default password]
+* https://github.com/neuvector/neuvector/security/advisories/GHSA-8ff6-pc43-jwv3[Insecure password management vulnerable to rainbow attacks]
+* https://github.com/neuvector/neuvector/security/advisories/GHSA-w54x-xfxg-4gxq[Process with sensitive arguments lead to leakage]
 
 === 5.4.5 July 2025
 

--- a/docs/5.4/modules/en/pages/5x.adoc
+++ b/docs/5.4/modules/en/pages/5x.adoc
@@ -36,6 +36,8 @@ To receive email notifications of new releases, please subscribe to this SUSE ma
 * https://github.com/neuvector/neuvector/security/advisories/GHSA-8ff6-pc43-jwv3[Insecure password management vulnerable to rainbow attacks]
 * https://github.com/neuvector/neuvector/security/advisories/GHSA-w54x-xfxg-4gxq[Process with sensitive arguments lead to leakage]
 
+See the xref:cve.adoc[Security Advisory and CVEs] documentation for more information.
+
 === 5.4.5 July 2025
 
 ==== New Features:

--- a/docs/5.4/modules/en/pages/cve.adoc
+++ b/docs/5.4/modules/en/pages/cve.adoc
@@ -7,7 +7,7 @@ NeuVector is committed to informing the community of security issues. Below is a
 == CVE List
 
 |===
-| ID | Description | Date | Resolution
+| ID | Description | Date | Release
 
 | https://github.com/neuvector/neuvector/security/advisories/GHSA-8pxw-9c75-6w56[CVE-2025-8077] 
 | For NeuVector deployment on the Kubernetes-based environment, the bootstrap password of the default admin user will be generated randomly and stored in a Kubernetes secret. The default admin will need to get the bootstrap password from the Kubernetes secret first and will be asked to change password after the first UI login is successful.

--- a/docs/5.4/modules/en/pages/cve.adoc
+++ b/docs/5.4/modules/en/pages/cve.adoc
@@ -1,19 +1,45 @@
-= Sensitive Information Exposure in NeuVector Manager Container Logs
-:page-opendocs-origin: /16.security_advisories/16.security_advisories.md
-:page-opendocs-slug:  /security_advisories/security_advisories/Exposure-ManagerContainerLogs
+= Security Advisories and CVEs
+:revdate: 2025-08-26
+:page-revdate: {revdate}
+
+NeuVector is committed to informing the community of security issues. Below is a CVE reference list of published security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved.
+
+== CVE List
+
+|===
+| ID | Description | Date | Resolution
+
+| https://github.com/neuvector/neuvector/security/advisories/GHSA-8pxw-9c75-6w56[CVE-2025-8077] 
+| For NeuVector deployment on the Kubernetes-based environment, the bootstrap password of the default admin user will be generated randomly and stored in a Kubernetes secret. The default admin will need to get the bootstrap password from the Kubernetes secret first and will be asked to change password after the first UI login is successful.
+| 25 Aug 2025 
+| https://github.com/neuvector/neuvector/releases/tag/v5.4.6[NeuVector v5.4.6]
+
+| https://github.com/neuvector/neuvector/security/advisories/GHSA-8ff6-pc43-jwv3[CVE-2025-53884] 
+| NeuVector uses a cryptographically secure salt with the PBKDF2 algorithm instead of a simple hash to protect user passwords.For rolling upgrades from earlier versions, NeuVector recalculates and stores the new password hash only after each user’s next successful login.
+| 25 Aug 2025 
+| https://github.com/neuvector/neuvector/releases/tag/v5.4.6[NeuVector v5.4.6]
+
+| https://github.com/neuvector/neuvector/security/advisories/GHSA-w54x-xfxg-4gxq[CVE-2025-54467] 
+| By default, NeuVector redacts process commands that contain the strings password,passwd, pwd, token, or key in security logs, syslog, enforcer debug logs, controller debug logs, webhooks, and support logs. Users can configure a Kubernetes ConfigMap to define custom regex patterns for additional process commands to redact.
+| 25 Aug 2025 
+| https://github.com/neuvector/neuvector/releases/tag/v5.4.6[NeuVector v5.4.6]
+
+|===
+
+== Sensitive Information Exposure in NeuVector Manager Container Logs
 
 *CVE ID:* CVE-2025-46808  
 *CVSS Score:* 6.8 — https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:N/A:N&version=3.1[AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:N/A:N]  
 *CWE:* https://cwe.mitre.org/data/definitions/532[CWE-532: Insertion of Sensitive Information into Log File]
 
-== Affected Versions
+=== Affected Versions
 
 * All versions earlier than `5.0.0`
 * Versions from `5.0.0` up to and including `5.4.4`
 
 *Fixed version: `5.4.5`*
 
-== Impact
+=== Impact
 
 A vulnerability has been identified in NeuVector versions up to and including `5.4.4`, where sensitive information is leaked into the manager container’s log. The following fields may be exposed:
 
@@ -69,11 +95,11 @@ In the patched version, the `X-R-Sess` value is partially masked for safety. Oth
 See also: https://attack.mitre.org/techniques/T1552/[MITRE Technique T1552: Unsecured Credentials].
 ====
 
-== Patches
+=== Patches
 
 Patched versions include `5.4.5` and above. Users should rotate any GitHub token used in Remote Repository Configuration after upgrading.
 
-== Workarounds
+=== Workarounds
 
 No workarounds are currently available. Upgrade to the fixed version as soon as possible.
 
@@ -81,6 +107,6 @@ No workarounds are currently available. Upgrade to the fixed version as soon as 
 
 * Contact the https://github.com/rancher/rancher/security/policy[SUSE Rancher Security team].
 * Open an issue in the https://github.com/neuvector/neuvector/issues/new/choose[NeuVector GitHub repository].
-* Review:
+* References:
   ** https://www.suse.com/suse-neuvector/support-matrix/all-supported-versions/neuvector-v-all-versions/[NeuVector Support Matrix]
   ** https://www.suse.com/lifecycle/#suse-security[Product Support Lifecycle]


### PR DESCRIPTION
Adding v5.4.6 release note and updating the CVEs section to incorporate CVE list as well as security advisory information. Based on shared release note file.